### PR TITLE
Dual proxy

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.6, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-[![Python package](https://github.com/scholarly-python-package/scholarly/workflows/Python%20package/badge.svg?branch=master)](https://github.com/scholarly-python-package/scholarly/actions?query=branch%3Amaster)
+[![Python package](https://github.com/scholarly-python-package/scholarly/workflows/Python%20package/badge.svg?branch=main)](https://github.com/scholarly-python-package/scholarly/actions?query=branch%3Amain)
 
 [![Documentation Status](https://readthedocs.org/projects/scholarly/badge/?version=latest)](https://scholarly.readthedocs.io/en/latest/?badge=latest)
 
 # scholarly
 
-scholarly is a module that allows you to retrieve author and publication information from [Google Scholar](https://scholar.google.com) in a friendly, Pythonic way.
+scholarly is a module that allows you to retrieve author and publication information from [Google Scholar](https://scholar.google.com) in a friendly, Pythonic way without having to solve CAPTCHAs.
 
 ## Important Note
 
-This is version 1.4 of the `scholarly` library. There has been a major refactor in the way the library operates and it's code structure and it **will break** most existing code, based on the previous (v0.x) versions.
+This is version 1.5 of the `scholarly` library. There has been a major refactor in the way the library operates and its code structure and it **will break** most existing code, based on the previous (v0.x) versions.
 
 ## Documentation
 

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -182,7 +182,7 @@ class Navigator(object, metaclass=Singleton):
                 self.logger.info("Retrying with a new session.")
 
             tries += 1
-            session, timeout = pm.get_next_proxy(num_tries = tries, old_timeout = timeout)
+            session, timeout = pm.get_next_proxy(num_tries = tries, old_timeout = timeout, old_proxy=session.proxies.get('http', None))
 
         # If secondary proxy does not work, try again primary proxy.
         if not premium:

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -149,7 +149,7 @@ class Navigator(object, metaclass=Singleton):
                         else:
                             if not pm._use_luminati:
                                 w = random.uniform(60, 2*60)
-                                self.logger.info("Will retry after {} seconds (with another session).".format(w))
+                                self.logger.info("Will retry after %.2f seconds (with another session).", w)
                                 time.sleep(w)
                         self._new_session(premium=premium)
                         self.got_403 = True
@@ -158,18 +158,18 @@ class Navigator(object, metaclass=Singleton):
                     else:
                         self.logger.info("We can use another connection... let's try that.")
                 else:
-                    self.logger.info(f"""Response code {resp.status_code}.
-                                    Retrying...""")
+                    self.logger.info("""Response code %d.
+                                    Retrying...""", resp.status_code)
 
             except DOSException:
                 if not pm.has_proxy():
                     self.logger.info("No other connections possible.")
                     w = random.uniform(60, 2*60)
-                    self.logger.info("Will retry after {} seconds (with the same session).".format(w))
+                    self.logger.info("Will retry after %.2f seconds (with the same session).", w)
                     time.sleep(w)
                     continue
             except Timeout as e:
-                err = f"Timeout Exception %s while fetching page: %s" % (type(e).__name__, e.args)
+                err = "Timeout Exception %s while fetching page: %s" % (type(e).__name__, e.args)
                 self.logger.info(err)
                 if timeout < 3*self._TIMEOUT:
                     self.logger.info("Increasing timeout and retrying within same session.")
@@ -177,7 +177,7 @@ class Navigator(object, metaclass=Singleton):
                     continue
                 self.logger.info("Giving up this session.")
             except Exception as e:
-                err = f"Exception %s while fetching page: %s" % (type(e).__name__, e.args)
+                err = "Exception %s while fetching page: %s" % (type(e).__name__, e.args)
                 self.logger.info(err)
                 self.logger.info("Retrying with a new session.")
 

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -6,7 +6,7 @@ import time
 import requests
 import stem.process
 import tempfile
-import os
+import os, sys
 
 from requests.exceptions import Timeout
 from selenium import webdriver
@@ -19,6 +19,7 @@ from urllib.parse import urlparse
 from stem import Signal
 from stem.control import Controller
 from fake_useragent import UserAgent
+from contextlib import contextmanager
 from dotenv import load_dotenv, find_dotenv
 
 class DOSException(Exception):
@@ -411,11 +412,13 @@ class ProxyGenerator(object):
         self._session = requests.Session()
         self.got_403 = False
 
-        _HEADERS = {
-            'accept-language': 'en-US,en',
-            'accept': 'text/html,application/xhtml+xml,application/xml',
-            'User-Agent': UserAgent().random,
-        }
+        # Suppress the misleading traceback from UserAgent()
+        with self._suppress_logger('fake_useragent'):
+            _HEADERS = {
+                'accept-language': 'en-US,en',
+                'accept': 'text/html,application/xhtml+xml,application/xml',
+                'User-Agent': UserAgent().random,
+            }
         self._session.headers.update(_HEADERS)
 
         if self._proxy_works:
@@ -551,3 +554,18 @@ class ProxyGenerator(object):
             self._new_session()
 
         return self._session, new_timeout
+
+    # A context manager to suppress the misleading traceback from UserAgent()
+    # Based on https://thesmithfam.org/blog/2012/10/25/temporarily-suppress-console-output-in-python/
+    @staticmethod
+    @contextmanager
+    def _suppress_logger(loggerName: str, level=logging.CRITICAL):
+        """Temporarily suppress logging output from a specific logger.
+        """
+        logger = logging.getLogger(loggerName)
+        original_level = logger.getEffectiveLevel()
+        logger.setLevel(level)
+        try:
+            yield
+        finally:
+            logger.setLevel(original_level)

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -141,7 +141,10 @@ class ProxyGenerator(object):
                 elif resp.status_code == 401:
                     self.logger.warning("Incorrect credentials for proxy!")
                     return False
+            except (TimeoutException, TimeoutError):
+                time.sleep(self._TIMEOUT)
             except Exception as e:
+                # import pdb; pdb.set_trace()
                 self.logger.warning("Exception while testing proxy: %s", e)
                 if ('lum' in proxies['http']) or ('scraperapi' in proxies['http']):
                     self.logger.warning("Double check your credentials and try increasing the timeout")
@@ -438,9 +441,29 @@ class ProxyGenerator(object):
         if self._webdriver:
             self._webdriver.quit()
 
+    # TODO: Consider making it a class method so pm1 and pm2 can share states
+    # TODO: Add a wait time instead of looping infinitely
+    def _fp_coroutine(self, timeout=1):
+        freeproxy = FreeProxy(rand=False, timeout=timeout)
+        dirty_proxies = set()
+        all_proxies = []
+        while True:
+            if not all_proxies:
+                all_proxies = freeproxy.get_proxy_list()
+                all_proxies.reverse()
+            proxy = all_proxies.pop()
+            if proxy in dirty_proxies:
+                continue
+            proxies = {'http': proxy, 'https': proxy}
+            proxy_works = True # self._check_proxy(proxies)
+            if proxy_works:
+                self._use_proxy(proxy, skip_checking_proxy=True)
+                dirty_proxy = (yield proxy)
+            dirty_proxies.update(dirty_proxy)
+
     def FreeProxies(self, timeout=1):
         """
-        Sets up a proxy from the free-proxy library
+        Sets up continuously rotating proxies from the free-proxy library
 
         :param timeout: Timeout for the proxy in seconds, optional
         :type timeout: float
@@ -451,17 +474,17 @@ class ProxyGenerator(object):
             pg = ProxyGenerator()
             success = pg.FreeProxies()
         """
-        freeproxy = FreeProxy(rand=True, timeout=timeout)
-        # Looping it 60000 times gives us a 85% chance that we try each proxy
-        # at least once.
-        for _ in range(60000):
-            proxy = freeproxy.get()
-            proxy_works = self._use_proxy(http=proxy, https=proxy)
-            if proxy_works:
-                return proxy_works
-
-        self.logger.info("None of the free proxies are working at the moment. "
-                         "Try again after a few minutes.")
+        # import pdb; pdb.set_trace()
+        self._fp_gen = self._fp_coroutine(timeout=timeout)
+        self._proxy_gen = self._fp_gen.send
+        proxy = next(self._fp_gen)
+        if proxy:
+            return True
+        else:
+            self._fp_gen.close()
+            self.logger.info("None of the free proxies are working at the moment. "
+                             "Try again after a few minutes.")
+            return False
 
     def ScraperAPI(self, API_KEY, country_code=None, premium=False, render=False, skip_checking_proxy=False):
         """
@@ -534,7 +557,7 @@ class ProxyGenerator(object):
         self._proxy_gen = gen
         return True
 
-    def get_next_proxy(self, num_tries = None, old_timeout = 3):
+    def get_next_proxy(self, num_tries = None, old_timeout = 3, old_proxy=None):
         new_timeout = old_timeout
         if self._can_refresh_tor:
             # Check if Tor is running and refresh it
@@ -543,12 +566,13 @@ class ProxyGenerator(object):
             time.sleep(5) # wait for the refresh to happen
             new_timeout = self._TIMEOUT # Reset timeout to default
         elif self._proxy_gen:
+            # import pdb; pdb.set_trace()
             if (num_tries):
                 self.logger.info("Try #%d failed. Switching proxy.", num_tries)
             # Try to get another proxy
-            new_proxy = self._proxy_gen()
+            new_proxy = self._proxy_gen(old_proxy)
             while (not self._use_proxy(new_proxy)):
-                new_proxy = self._proxy_gen()
+                new_proxy = self._proxy_gen(new_proxy)
             new_timeout = self._TIMEOUT # Reset timeout to default
         else:
             self._new_session()

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -443,7 +443,8 @@ class ProxyGenerator(object):
 
     # TODO: Consider making it a class method so pm1 and pm2 can share states
     # TODO: Add a wait time instead of looping infinitely
-    def _fp_coroutine(self, timeout=1):
+    @classmethod
+    def _fp_coroutine(cls, timeout=1):
         freeproxy = FreeProxy(rand=False, timeout=timeout)
         dirty_proxies = set()
         all_proxies = []
@@ -455,9 +456,9 @@ class ProxyGenerator(object):
             if proxy in dirty_proxies:
                 continue
             proxies = {'http': proxy, 'https': proxy}
-            proxy_works = True # self._check_proxy(proxies)
+            proxy_works = True  # self._check_proxy(proxies)
             if proxy_works:
-                self._use_proxy(proxy, skip_checking_proxy=True)
+                # self._use_proxy(proxy, skip_checking_proxy=True)
                 dirty_proxy = (yield proxy)
             dirty_proxies.update(dirty_proxy)
 
@@ -475,16 +476,24 @@ class ProxyGenerator(object):
             success = pg.FreeProxies()
         """
         # import pdb; pdb.set_trace()
-        self._fp_gen = self._fp_coroutine(timeout=timeout)
+        self._fp_gen = ProxyGenerator._fp_coroutine(timeout=timeout)
         self._proxy_gen = self._fp_gen.send
         proxy = next(self._fp_gen)
-        if proxy:
-            return True
-        else:
+        proxy_works = False
+        n_retries = 200
+        n_tries = 0
+        while (not proxy_works) and (n_tries < n_retries):
+            proxy_works = self._use_proxy(proxy)
+            n_tries += 1
+            if not proxy_works:
+                proxy = self._proxy_gen(proxy)
+        if n_tries==n_retries:
             self._fp_gen.close()
             self.logger.info("None of the free proxies are working at the moment. "
                              "Try again after a few minutes.")
             return False
+        else:
+            return True
 
     def ScraperAPI(self, API_KEY, country_code=None, premium=False, render=False, skip_checking_proxy=False):
         """

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -541,7 +541,7 @@ class ProxyGenerator(object):
             new_timeout = self._TIMEOUT # Reset timeout to default
         elif self._proxy_gen:
             if (num_tries):
-                self.logger.info(f"Try #{num_tries} failed. Switching proxy.") # TODO: add tries
+                self.logger.info("Try #%d failed. Switching proxy.", num_tries)
             # Try to get another proxy
             new_proxy = self._proxy_gen()
             while (not self._use_proxy(new_proxy)):

--- a/test_module.py
+++ b/test_module.py
@@ -58,6 +58,7 @@ class TestScholarly(unittest.TestCase):
             scholarly.use_proxy(None)
 
     def tearDown(self):
+        return
         if self.connection_method == "freeproxy":
             scholarly._Scholarly__nav.pm1._fp_gen.close()
         scholarly._Scholarly__nav.pm2._fp_gen.close()

--- a/test_module.py
+++ b/test_module.py
@@ -57,6 +57,11 @@ class TestScholarly(unittest.TestCase):
         else:
             scholarly.use_proxy(None)
 
+    def tearDown(self):
+        if self.connection_method == "freeproxy":
+            scholarly._Scholarly__nav.pm1._fp_gen.close()
+        scholarly._Scholarly__nav.pm2._fp_gen.close()
+
     @unittest.skipUnless([_bin for path in sys.path if os.path.isdir(path) for _bin in os.listdir(path)
                           if _bin=='tor' or _bin=='tor.exe'], reason='Tor executable not found')
     def test_tor_launch_own_process(self):
@@ -301,7 +306,7 @@ class TestScholarly(unittest.TestCase):
         serialized = json.dumps(pub)
         pub_loaded = json.loads(serialized, object_hook=cpy_decoder)
         self.assertEqual(pub, pub_loaded)
-        
+
     def test_full_title(self):
         """
         Test if the full title of a long title-publication gets retrieved.


### PR DESCRIPTION
This is the first in a series of PR achieving the v1.5 milestone. This PR introduces a dual proxy mode to reduce the number of calls made through premium proxy services such as ScraperAPI or Luminati {Bright Data) and use those resources judiciously. These changes are made mainly to extend the reach of small-sized projects and proof-of-concepts with `scholarly` with the free plan of ScraperAPI before investing in paid plans.

The changes are fully compatible with existing applications (hence can go in v1.4.4 if there's a pressing need). However under the hood, it uses FreeProxy by default to scrape pages that are not blocked by G Scholar while the premium, expensive proxy modes are reserved for the pages that are actively blocked by anti-bots. The switching between the two proxy managers happens internally, so the user doesn't have to worry about the kind of page scraped.

This significantly reduces the number of calls through ScraperAPI/Luminati. Running the full suite of unit tests involves only 22 calls to ScraperAPI as opposed to 57 calls before (sufficient to run the daily tests with the free plan during the months of low activity). 

The tests pass for now, but I would like it to be a part of `main` branch for a few days before the release so we can monitor if FreeProxy is robust enough. In the mean time, I have a few other PRs that I'm working on that need to get merged before releasing 1.5.